### PR TITLE
Add Claude session initialization with git configuration

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) sessions
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Configure git identity
+git config --global user.name "Bruno Binet"
+git config --global user.email "bruno.binet@gmail.com"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds automated session initialization for Claude Code on the web by configuring git identity when a remote session starts.

## Key Changes
- Added `.claude/settings.json` to define session hooks that trigger on `SessionStart` events
- Added `.claude/hooks/session-start.sh` script that:
  - Only executes in remote Claude Code sessions (checks `CLAUDE_CODE_REMOTE` environment variable)
  - Automatically configures git user name and email for the session
  - Uses strict bash error handling (`set -euo pipefail`)

## Implementation Details
The session start hook is designed to be non-intrusive—it exits early if not running in a remote session, ensuring it won't interfere with local development workflows. The git configuration is set at the global level for the session, allowing commits to be properly attributed without manual setup.

https://claude.ai/code/session_01CVrLPCyXH6z2oGJd2wQTV8