### PR TITLE
Add Salt Master Docker image with systemd support

### DIFF
--- a/docker/salt-master/Dockerfile
+++ b/docker/salt-master/Dockerfile
@@ -1,0 +1,118 @@
+FROM debian:bullseye
+
+LABEL maintainer="Bruno Binet <bruno.binet@helioslite.com>"
+
+ENV container=docker
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Locale setup
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends locales && \
+    rm -rf /var/lib/apt/lists/* && \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG=en_US.utf8
+
+# Install system packages (without salt — installed via pip below)
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    systemd systemd-sysv dbus \
+    vim less net-tools procps lsb-release git patch \
+    openssh-client make gnupg curl sudo \
+    python3-apt python3-git python3-openssl \
+    python3-pip python3-setuptools python3-wheel python3-venv \
+    python3-zmq python3-msgpack python3-jinja2 python3-yaml \
+    python3-markupsafe python3-certifi python3-dateutil \
+    python3-requests python3-tornado python3-distro \
+    expect \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Salt 3003 and dependencies via pip
+RUN pip3 install --no-cache-dir \
+        salt==3003 \
+        CherryPy \
+        https://github.com/salt-formulas/reclass/archive/v1.7.0.zip
+
+# Dirty fix issue https://github.com/saltstack/salt/issues/59990
+# (reverting: https://github.com/saltstack/salt/pull/59866)
+COPY salt_v3003_master_tops.patch /tmp/salt_v3003_master_tops.patch
+RUN patch /usr/local/lib/python3.9/dist-packages/salt/master.py /tmp/salt_v3003_master_tops.patch
+
+# Create salt systemd service (since we installed via pip, no service file is provided)
+RUN cat <<'EOF' > /etc/systemd/system/salt-master.service
+[Unit]
+Description=The Salt Master Server
+Documentation=man:salt-master(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltproject.io/en/latest/contents.html
+After=network.target
+
+[Service]
+Type=notify
+NotifyAccess=all
+LimitNOFILE=100000
+ExecStart=/usr/local/bin/salt-master
+WatchdogSec=60
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+RUN cat <<'EOF' > /etc/systemd/system/salt-api.service
+[Unit]
+Description=The Salt API
+Documentation=man:salt-api(1) file:///usr/share/doc/salt/html/contents.html https://docs.saltproject.io/en/latest/contents.html
+After=network.target salt-master.service
+
+[Service]
+Type=simple
+LimitNOFILE=100000
+ExecStart=/usr/local/bin/salt-api
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+RUN systemctl enable salt-master.service salt-api.service
+
+# Set default target to multi-user (not graphical)
+RUN systemctl set-default multi-user.target
+
+# Mask unnecessary systemd services for container usage
+RUN systemctl mask \
+    dev-hugepages.mount \
+    sys-fs-fuse-connections.mount \
+    sys-kernel-config.mount \
+    display-manager.service \
+    getty@.service \
+    systemd-logind.service \
+    systemd-remount-fs.service \
+    getty.target \
+    graphical.target
+
+# Fix dbus OOMScoreAdjust (not allowed in containers)
+RUN cp /lib/systemd/system/dbus.service /etc/systemd/system/; \
+    sed -i 's/OOMScoreAdjust=.*//' /etc/systemd/system/dbus.service
+
+# Install entrypoint and service files
+COPY entry.sh /usr/bin/entry.sh
+RUN chmod +x /usr/bin/entry.sh
+COPY resin.service /etc/systemd/system/resin.service
+RUN systemctl enable /etc/systemd/system/resin.service
+
+COPY override.conf /etc/systemd/system/salt-master.service.d/override.conf
+COPY pre-salt-master.sh /usr/local/bin/pre-salt-master.sh
+RUN chmod +x /usr/local/bin/pre-salt-master.sh
+
+# Molten web UI
+ENV MOLTEN_VERSION=0.3.2
+ENV MOLTEN_MD5=4bce824944e6a2f5d09d703af53d596d
+ADD https://github.com/martinhoefling/molten/releases/download/v${MOLTEN_VERSION}/molten-${MOLTEN_VERSION}.tar.gz molten-${MOLTEN_VERSION}.tar.gz
+RUN echo "${MOLTEN_MD5}  molten-${MOLTEN_VERSION}.tar.gz" | md5sum --check && \
+    mkdir -p /opt/molten && tar -xf molten-${MOLTEN_VERSION}.tar.gz -C /opt/molten --strip-components=1 && \
+    rm -f molten-${MOLTEN_VERSION}.tar.gz
+
+# salt-master, salt-api
+EXPOSE 4505 4506 443 8000
+
+ENV BEFORE_EXEC_SCRIPT=/etc/salt/before-exec.sh
+
+STOPSIGNAL 37
+ENTRYPOINT ["/usr/bin/entry.sh"]
+CMD ["/bin/date"]

--- a/docker/salt-master/entry.sh
+++ b/docker/salt-master/entry.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+set -m
+
+# This command only works in privileged container
+if ip link add dummy0 type dummy &> /dev/null; then
+	PRIVILEGED=true
+	# clean the dummy0 link
+	ip link delete dummy0 &> /dev/null
+else
+	PRIVILEGED=false
+fi
+
+# Send SIGTERM to child processes of PID 1.
+function signal_handler()
+{
+	kill "$pid"
+}
+
+function mount_dev()
+{
+	tmp_dir='/tmp/tmpmount'
+	mkdir -p "$tmp_dir"
+	mount -t devtmpfs none "$tmp_dir"
+	mkdir -p "$tmp_dir/shm"
+	mount --move /dev/shm "$tmp_dir/shm"
+	mkdir -p "$tmp_dir/mqueue"
+	mount --move /dev/mqueue "$tmp_dir/mqueue"
+	mkdir -p "$tmp_dir/pts"
+	mount --move /dev/pts "$tmp_dir/pts"
+	touch "$tmp_dir/console"
+	mount --move /dev/console "$tmp_dir/console"
+	umount /dev || true
+	mount --move "$tmp_dir" /dev
+
+	# Since the devpts is mounted with -o newinstance by Docker, we need to make
+	# /dev/ptmx point to its ptmx.
+	# ref: https://www.kernel.org/doc/Documentation/filesystems/devpts.txt
+	ln -sf /dev/pts/ptmx /dev/ptmx
+	mount -t debugfs nodev /sys/kernel/debug || true
+}
+
+function init_systemd()
+{
+	GREEN='\033[0;32m'
+	echo -e "${GREEN}Systemd init system enabled."
+	for var in $(compgen -e); do
+		printf '%q=%q\n' "$var" "${!var}"
+	done > /etc/docker.env
+	echo 'source /etc/docker.env' >> ~/.bashrc
+
+	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
+	printf '%q ' "$@" >> /etc/resinApp.sh
+	chmod +x /etc/resinApp.sh
+
+	mkdir -p /etc/systemd/system/resin.service.d
+	cat <<-EOF > /etc/systemd/system/resin.service.d/override.conf
+		[Service]
+		WorkingDirectory=$(pwd)
+	EOF
+
+	sleep infinity &
+	exec env DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket /sbin/init quiet systemd.show_status=0
+}
+
+function init_non_systemd()
+{
+	# trap the stop signal then send SIGTERM to user processes
+	trap signal_handler SIGRTMIN+3 SIGTERM
+
+	# echo error message, when executable file doesn't exist.
+	if CMD=$(command -v "$1" 2>/dev/null); then
+		shift
+		"$CMD" "$@" &
+		pid=$!
+		wait "$pid"
+		exit_code=$?
+		fg &> /dev/null || exit "$exit_code"
+	else
+		echo "Command not found: $1"
+		exit 1
+	fi
+}
+
+INITSYSTEM=${INITSYSTEM:-on}
+INITSYSTEM=$(echo "$INITSYSTEM" | awk '{print tolower($0)}')
+
+case "$INITSYSTEM" in
+	'1' | 'true')
+		INITSYSTEM='on'
+	;;
+esac
+
+if $PRIVILEGED; then
+	# Only run mount_dev in privileged container
+	mount_dev
+fi
+
+if [ "$INITSYSTEM" = "on" ]; then
+	init_systemd "$@"
+else
+	init_non_systemd "$@"
+fi

--- a/docker/salt-master/override.conf
+++ b/docker/salt-master/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPre=/usr/local/bin/pre-salt-master.sh
+TimeoutStartSec=300

--- a/docker/salt-master/pre-salt-master.sh
+++ b/docker/salt-master/pre-salt-master.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Import our environment variables from systemd
+while IFS= read -rd '' var; do export "$var"; done </proc/1/environ
+
+abort() {
+    msg="$1"
+    echo "$msg"
+    echo "=> Environment was:"
+    env
+    echo "=> Program terminated!"
+    exit 1
+}
+
+create_user() {
+    user=$1
+    password=$2
+    if [ -z "${user}" ] || [ -z "${password}" ]; then
+        abort "=> create_user 2 args are required (user, password)."
+    fi
+    useradd ${user}
+    echo "${user}:${password}" | chpasswd
+    if [ $? -eq 0 ]; then
+        echo "=> User \"${user}\" ok."
+    else
+        abort "=> Failed to create user \"${user}\"!"
+    fi
+}
+
+# create users from environment variables and docker secrets
+if [ -z "${PRE_CREATE_USERS}" ]; then
+    echo "=> No user names supplied: no user will be created."
+else
+    for user in $(echo ${PRE_CREATE_USERS} | tr "," "\n"); do
+        if [ -f "/run/secrets/${user}.password" ]
+        then
+            create_user $user $(cat "/run/secrets/${user}.password")
+        else
+            userpassword_var="${user}_PASSWORD"
+            create_user $user ${!userpassword_var}
+        fi
+    done
+fi
+
+# create salt master keys from env variables
+if [ -n "${KEY_MASTER_PRIV}" ]; then
+    if [ -z "${KEY_MASTER_PUB}" ]; then
+        abort "=> Both KEY_MASTER_PRIV and KEY_MASTER_PUB should be set."
+    fi
+    echo "=> Overwriting master public & private key"
+    mkdir -p "/etc/salt/pki/master"
+    chmod 700 "/etc/salt/pki/master"
+    echo -e "${KEY_MASTER_PRIV}" > "/etc/salt/pki/master/master.pem"
+    echo -e "${KEY_MASTER_PUB}" > "/etc/salt/pki/master/master.pub"
+fi
+
+# create salt master keys from docker secrets
+if [ -f /run/secrets/master.pem ] && [ -f /run/secrets/master.pub ]
+then
+    mkdir -p "/etc/salt/pki/master"
+    chmod 700 "/etc/salt/pki/master"
+    echo "=> Overwriting master public & private key from docker secrets"
+    cp /run/secrets/master.pem "/etc/salt/pki/master/master.pem"
+    cp /run/secrets/master.pub "/etc/salt/pki/master/master.pub"
+fi
+
+if [ -f "/etc/salt/pki/master/master.pem" ]
+then
+    if [ -z "${PRE_ACCEPT_MINIONS}" ]; then
+        echo "=> No minion key supplied: no minion key will be pre-accepted."
+    else
+        for minion in $(echo ${PRE_ACCEPT_MINIONS} | tr "," "\n"); do
+            mkdir -p "/etc/salt/pki/master/minions"
+            minionkey_var="${minion//-/_}_KEY"
+            if [ -f "/run/secrets/${minion}.pub" ]
+            then
+                echo "=> Overwriting minion ${minion} key from docker secrets"
+                cp "/run/secrets/${minion}.pub" "/etc/salt/pki/master/minions/${minion}"
+            elif ! [ -z "${!minionkey_var}" ]
+            then
+                echo "=> Overwriting minion ${minion} key from env variables"
+                echo -e "${!minionkey_var}" > "/etc/salt/pki/master/minions/${minion}"
+            else
+                abort "=> Failed to preaccept minion \"${minion}\"!"
+            fi
+        done
+    fi
+fi
+
+
+BEFORE_EXEC_SCRIPT=${BEFORE_EXEC_SCRIPT:-/etc/salt/before-exec.sh}
+if [ -x "${BEFORE_EXEC_SCRIPT%% *}" ]
+then
+    echo "=> Running BEFORE_EXEC_SCRIPT [$BEFORE_EXEC_SCRIPT]..."
+    $BEFORE_EXEC_SCRIPT
+    if [ $? -ne 0 ]
+    then
+        abort "=> BEFORE_EXEC_SCRIPT [$BEFORE_EXEC_SCRIPT] has failed."
+    fi
+fi

--- a/docker/salt-master/resin.service
+++ b/docker/salt-master/resin.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Resin.io User Application
+
+[Service]
+EnvironmentFile=/etc/docker.env
+ExecStart=/etc/resinApp.sh
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/console
+Restart=on-failure
+
+[Install]
+WantedBy=basic.target

--- a/docker/salt-master/salt_v3003_master_tops.patch
+++ b/docker/salt-master/salt_v3003_master_tops.patch
@@ -1,0 +1,22 @@
+diff --git a/salt/master.py b/salt/master.py
+index e33d76905d..cddc12efdd 100644
+--- a/salt/master.py
++++ b/salt/master.py
+@@ -1204,6 +1204,7 @@ class AESFuncs(TransportMethods):
+     expose_methods = (
+         "verify_minion",
+         "_master_tops",
++        "_ext_nodes",
+         "_master_opts",
+         "_mine_get",
+         "_mine",
+@@ -1428,6 +1429,9 @@ class AESFuncs(TransportMethods):
+             return {}
+         return self.masterapi._master_tops(load, skip_verify=True)
+
++    # Needed so older minions can request master_tops
++    _ext_nodes = _master_tops
++
+     def _master_opts(self, load):
+         """
+         Return the master options to the minion


### PR DESCRIPTION
## Summary
This PR introduces a complete Docker image for Salt Master (v3003) with systemd initialization support, including Salt API and Molten web UI integration.

## Key Changes
- **Dockerfile**: Creates a Debian Bullseye-based image with:
  - Salt 3003 and dependencies installed via pip
  - Systemd as init system with proper service files for salt-master and salt-api
  - Molten web UI (v0.3.2) for Salt management interface
  - Patch for Salt issue #59990 to restore `_ext_nodes` method compatibility
  - Proper systemd service masking for container environments
  - Exposed ports: 4505, 4506 (Salt), 443 (API/UI)

- **entry.sh**: Container entrypoint script that:
  - Detects privileged vs unprivileged container mode
  - Handles device mounting for privileged containers
  - Supports both systemd and non-systemd initialization modes
  - Manages signal handling for graceful shutdown

- **pre-salt-master.sh**: Pre-execution setup script that:
  - Creates users from environment variables or Docker secrets
  - Configures Salt master keys from environment or secrets
  - Pre-accepts minion keys for automated cluster setup
  - Executes optional custom before-exec scripts

- **Service files**:
  - `salt-master.service`: Systemd unit for Salt Master daemon
  - `salt-api.service`: Systemd unit for Salt API
  - `resin.service`: User application service wrapper
  - `override.conf`: Service overrides with pre-execution hook and timeout configuration

## Notable Implementation Details
- Uses pip for Salt installation to avoid Debian package limitations
- Includes patch for Salt 3003 compatibility with older minions
- Supports both environment variables and Docker secrets for sensitive configuration
- Flexible initialization system (systemd or direct command execution)
- Proper signal handling (STOPSIGNAL 37) for container lifecycle management

https://claude.ai/code/session_01Syn3nag7vPWRGqamsMbhnw